### PR TITLE
Start API From Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ npm start
 open http://localhost:3000
 ```
 
+To run the API:
+
+```bash
+docker-compose up api
+```
+
+This will start the Feathers API and a Mongodb container.
+
 ## Testing
 
 We use [Mocha](https://mochajs.org/), [Chai](http://chaijs.com/), and [Enzyme](http://airbnb.io/enzyme/docs/api/index.html) to test components.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  api:
+    image: quay.io/codaisseur/code-assignments
+    entrypoint: ''
+    environment:
+      - DATABASE_URL=mongodb://mongodb:27017/
+    command: npm start --no-deprecation
+    depends_on:
+      - mongodb
+    ports:
+      - "5000:5000"
+
+  mongodb:
+    image: mongo
+    ports:
+      - "27017:27017"

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -4,7 +4,7 @@ import feathers from 'feathers-client';
 class API {
   constructor() {
     // Establish a Socket.io connection
-    const socket = io(process.env.FEATHERS_API_URL);
+    const socket = io(process.env.FEATHERS_API_URL || 'http://localhost:5000');
     // Initialize our Feathers client application through Socket.io
     // with hooks and authentication.
     this.app = feathers()


### PR DESCRIPTION
In this pull:

- Added a Docker Compose file to easily start the corresponding API.
- Instructions to start the API added to the README
- Updated the default API URL in the Api middleware to match that of the docker-compose config.